### PR TITLE
fix(contact): complete Web3Forms integration with hCaptcha

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -46,8 +46,12 @@ import { Icon } from 'astro-icon/components'
             <Checkbox name="keyboard-nav" value="keyboard" label="Keyboard navigation" />
           </Fieldset>-->
 
-          <Button htmlType="submit" type="primary">Send Message</Button>
+          <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+           <div class="h-captcha" data-captcha="true"></div>
+            <Button htmlType="submit" type="primary">Send Message</Button>
+          </div>
         </Form>
+      <script src="https://web3forms.com/client/script.js" async defer></script>
       </div>
       <div class="space-content">
         <Heading level="h3">Contact us</Heading>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -15,7 +15,8 @@ import { Icon } from 'astro-icon/components'
   <section class="container">
     <div class="grid grid-cols-1 gap-32 md:grid-cols-2">
       <div class="space-content">
-        <Form name="contact" action="/thank-you" method="post">
+        <Form name="contact" action="https://api.web3forms.com/submit" method="post">
+         <input type="hidden" name="access_key" value="e7696e12-3418-4990-b7e1-89a62e4bca25">
           <!-- Input field with custom validation message -->
           <Input
             name="firstname"

--- a/src/pages/thank-you.astro
+++ b/src/pages/thank-you.astro
@@ -9,10 +9,6 @@ import { Icon } from 'astro-icon/components'
   <PageHeader title="Splendid!" subtitle="The form was successfully validated." bgType="gradient" />
   <section class="container my-16">
     <div class="space-content">
-      <Notification type="info">
-        <Icon aria-hidden="true" name="lucide:info" size={24} />
-        <p>This was a test of the form validation system, no email was sent 😉.</p>
-      </Notification>
       <Link href="/contact" isButton type="primary" animateOnHover animation="boop" pulse>
         <Icon aria-hidden="true" name="lucide:mail" size={24} />
         Send another message


### PR DESCRIPTION
- Add Web3Forms API endpoint and access key
- Inline hCaptcha layout (captcha left, button right on desktop)
- Mobile responsive stacked layout  
- Script placement per Web3Forms docs
- Form validation ready

closes #11 