### PR TITLE
Accessibility review

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -62,6 +62,29 @@ import { Icon } from 'astro-icon/components'
           </div>
         </Form>
       <script src="https://web3forms.com/client/script.js" async defer></script>
+      <script define:vars={{ formName: 'contact' }}>
+        document.addEventListener('DOMContentLoaded', () => {
+          const form = document.querySelector(`form[name="${formName}"]`);
+          const errorRegion = document.getElementById('form-errors');
+
+          // accessible-astro-components Form validates required fields then calls
+          // form.submit() directly — bypassing submit event listeners entirely.
+          // Override form.submit() on this instance so hCaptcha is checked first.
+          const nativeSubmit = HTMLFormElement.prototype.submit.bind(form);
+          form.submit = function () {
+            const hCaptcha = form.querySelector('textarea[name="h-captcha-response"]');
+
+            if (!hCaptcha || !hCaptcha.value) {
+              errorRegion.textContent = 'Please complete the captcha before submitting.';
+              errorRegion.classList.remove('sr-only', 'border-transparent');
+              errorRegion.focus();
+              return;
+            }
+
+            nativeSubmit();
+          };
+        });
+      </script>
       </div>
       <div class="space-content">
         <Heading level="h3">Contact us</Heading>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -62,9 +62,9 @@ import { Icon } from 'astro-icon/components'
           </div>
         </Form>
       <script src="https://web3forms.com/client/script.js" async defer></script>
-      <script define:vars={{ formName: 'contact' }}>
+      <script>
         function initCaptchaGuard() {
-          const form = document.querySelector(`form[name="${formName}"]`);
+          const form = document.querySelector('form.js-validate');
           if (!form || form.dataset.captchaGuard === 'true') return;
           form.dataset.captchaGuard = 'true';
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -17,15 +17,6 @@ import { Icon } from 'astro-icon/components'
       <div class="space-content">
         <Form name="contact" action="https://api.web3forms.com/submit" method="post">
          <input type="hidden" name="access_key" value="e7696e12-3418-4990-b7e1-89a62e4bca25">
-          <!-- Form errors -->
-          <div id="form-errors" 
-              role="alert" 
-              aria-live="polite" 
-              class="mb-4 p-4 rounded-lg border-2 border-transparent bg-white sr-only focus-within:not(:empty):not(.sr-only) border-error text-error"
-              tabindex="-1">
-              Please complete the captcha before submitting. 
-            <a href="#captcha-help" class="underline">Focus captcha</a>.
-          </div>
          
          <!-- Input field with custom validation message -->
           <Input
@@ -68,7 +59,8 @@ import { Icon } from 'astro-icon/components'
           if (!form || form.dataset.captchaGuard === 'true') return;
           form.dataset.captchaGuard = 'true';
 
-          const errorRegion = document.getElementById('form-errors');
+          const errorNotification = form.querySelector('.notification');
+          const errorNotificationContent = errorNotification?.querySelector('p');
 
           // accessible-astro-components Form validates required fields then calls
           // form.submit() directly — bypassing submit event listeners entirely.
@@ -78,9 +70,11 @@ import { Icon } from 'astro-icon/components'
             const hCaptcha = form.querySelector('textarea[name="h-captcha-response"]');
 
             if (!hCaptcha || !hCaptcha.value) {
-              errorRegion.textContent = 'Please complete the captcha before submitting.';
-              errorRegion.classList.remove('sr-only', 'border-transparent');
-              errorRegion.focus();
+              errorNotificationContent.textContent = 'Please complete the captcha before submitting.';
+              errorNotification.setAttribute('tabindex', '-1');
+              errorNotification.hidden = false;
+              errorNotification.focus();
+              errorNotification.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
               return;
             }
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -17,7 +17,17 @@ import { Icon } from 'astro-icon/components'
       <div class="space-content">
         <Form name="contact" action="https://api.web3forms.com/submit" method="post">
          <input type="hidden" name="access_key" value="e7696e12-3418-4990-b7e1-89a62e4bca25">
-          <!-- Input field with custom validation message -->
+          <!-- Form errors -->
+          <div id="form-errors" 
+              role="alert" 
+              aria-live="polite" 
+              class="mb-4 p-4 rounded-lg border-2 border-transparent bg-white sr-only focus-within:not(:empty):not(.sr-only) border-error text-error"
+              tabindex="-1">
+              Please complete the captcha before submitting. 
+            <a href="#captcha-help" class="underline">Focus captcha</a>.
+          </div>
+         
+         <!-- Input field with custom validation message -->
           <Input
             name="firstname"
             label="First name"

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -63,8 +63,11 @@ import { Icon } from 'astro-icon/components'
         </Form>
       <script src="https://web3forms.com/client/script.js" async defer></script>
       <script define:vars={{ formName: 'contact' }}>
-        document.addEventListener('DOMContentLoaded', () => {
+        function initCaptchaGuard() {
           const form = document.querySelector(`form[name="${formName}"]`);
+          if (!form || form.dataset.captchaGuard === 'true') return;
+          form.dataset.captchaGuard = 'true';
+
           const errorRegion = document.getElementById('form-errors');
 
           // accessible-astro-components Form validates required fields then calls
@@ -83,7 +86,11 @@ import { Icon } from 'astro-icon/components'
 
             nativeSubmit();
           };
-        });
+        }
+
+        // DOMContentLoaded for hard navigations, astro:page-load for View Transitions
+        document.addEventListener('DOMContentLoaded', initCaptchaGuard);
+        document.addEventListener('astro:page-load', initCaptchaGuard);
       </script>
       </div>
       <div class="space-content">

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -17,6 +17,7 @@ import { Icon } from 'astro-icon/components'
       <div class="space-content">
         <Form name="contact" action="https://api.web3forms.com/submit" method="post">
          <input type="hidden" name="access_key" value="e7696e12-3418-4990-b7e1-89a62e4bca25">
+         <input type="hidden" name="redirect" value="https://zivawernick.com/thank-you">
          
          <!-- Input field with custom validation message -->
           <Input


### PR DESCRIPTION
 ## Fix contact form hCaptcha validation and submission
 
 ### Problem
 The contact form accepted submissions without requiring the hCaptcha 
 challenge to be completed. The form could be submitted freely, bypassing 
 bot protection entirely.
 
 ### Root causes
 - The `accessible-astro-components` Form component calls `form.submit()` 
   programmatically after its own field validation, which bypasses `submit` 
   event listeners entirely — the original captcha check never executed
 - The form selector `form[name="contact"]` returned null because the Form 
   component extracts the `name` prop but never forwards it to the rendered 
   `<form>` element
 - `DOMContentLoaded` does not fire on View Transition navigations, so the 
   captcha guard was never initialised when arriving at `/contact` via the nav
 
 ### Changes
 - Override `form.submit()` on the form instance to intercept programmatic 
   submissions and validate hCaptcha before allowing them through
 - Switch selector to `form.js-validate` (the class the component reliably adds)
 - Add `astro:page-load` listener alongside `DOMContentLoaded` for View 
   Transitions compatibility
 - Replace custom `#form-errors` div with the Form component's built-in 
   `.notification` element so the captcha error matches the accessible red 
   error styling used for field validation
 - Add redirect to `/thank-you` after successful submission
 
 Closes #28 