### PR TITLE
fix(a11y): change hero subtitle from h2 to paragraph

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -29,9 +29,9 @@ const { src = '/moon-3.jpg' }: Props = Astro.props
         <h1 class="text-center text-6xl md:text-left lg:text-8xl">
           <slot><span class="text-gradient ">Ziva Wernick</span> </slot>
         </h1>
-        <h2 class="max-w-2xl text-pretty text-3xl font-large text-white/92 md:text-4xl outlined-text">
+        <p class="subtitle max-w-2xl text-pretty text-3xl font-large text-white/92 md:text-4xl outlined-text">
           Software Developer Building Tech for Social Impact
-        </h2>
+        </p>
         <div class="flex flex-col gap-3 min-[500px]:flex-row">
           <Link
             href="https://github.com/ziva-wernick/radiant-zivawernick"
@@ -62,6 +62,11 @@ const { src = '/moon-3.jpg' }: Props = Astro.props
 <style lang="scss">
   h1 {
     text-wrap: unset;
+  }
+  .subtitle {
+    /* Keep the base h2 typography now that the subtitle is a paragraph */
+    font-family: var(--font-heading);
+    font-weight: 600;
   }
   .outlined-text {
     /* More saturated colors (500 range) for better contrast against white text and moon */


### PR DESCRIPTION
## Summary
Fixes the broken heading hierarchy in the Hero component: the H1 was followed directly by an H2 subtitle. The subtitle is supporting text, not a section heading, so it is now a `<p>` element (WCAG 1.3.1 Info and Relationships).

## Changes
- `src/components/Hero.astro`: subtitle `<h2>` → `<p class="subtitle ...">`
- Added a scoped `.subtitle` rule with `font-family: var(--font-heading)` and `font-weight: 600` — these came from the global base `h2` styles and would otherwise be lost, so the rendered visual is unchanged.

## Verification
- `npm run build` passes; built homepage renders the subtitle as `<p>` with identical utility classes.
- Page outline now has a single H1 followed by legitimate section H2s only.

Closes #9