### PR TITLE
fix(a11y): change TechAvatar root from li to div

### DIFF
--- a/src/components/TechAvatar.astro
+++ b/src/components/TechAvatar.astro
@@ -3,7 +3,7 @@ import { Icon } from 'astro-icon/components'
 const { icon, title, subtitle } = Astro.props
 ---
 
-<li class="tech-avatar">
+<div class="tech-avatar">
   <div class="tech-avatar-icon-wrap" aria-hidden="true">
     <Icon name={icon} class="tech-avatar-icon" />
   </div>
@@ -11,7 +11,7 @@ const { icon, title, subtitle } = Astro.props
     <span class="title">{title}</span>
     {subtitle && <span class="subtitle">{subtitle}</span>}
   </div>
-</li>
+</div>
 
 <style>
   .tech-avatar {
@@ -22,7 +22,6 @@ const { icon, title, subtitle } = Astro.props
     border-radius: var(--radius-md);
     padding: 0.75rem;
     max-width: 220px;
-    list-style: none;
   }
 
   .tech-avatar-icon-wrap {


### PR DESCRIPTION
## Summary
- Fixes WCAG 1.3.1 issue #21 from `ACCESSIBILITY-AUDIT.md`: `TechAvatar.astro` rendered a bare `<li>` with no `<ul>`/`<ol>` parent.
- The audit suggested wrapping the parent in a `<ul>`, but `TechAvatar` is always rendered inside `accessible-astro-components`' `<AvatarGroup>`, which renders a flex/grid `<div>` (not a list) - so there's no list context to attach to, and a `<div>` isn't valid direct content of a `<ul>` either.
- Changes `TechAvatar`'s root element to `<div>` to match its actual container, removing the invalid/orphaned list markup.