### PR TITLE
docs: refresh AGENTS.md and add public CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
 # AI Agents & Assistants Context (AGENTS.md)
 
-This document provides essential context for AI agents (like GitHub Copilot, Cursor, ChatGPT, Claude) working on the Accessible Astro Starter project. It outlines the project structure, coding standards, and architectural decisions to ensure consistent, high-quality contributions.
+This document provides essential context for AI agents (like GitHub Copilot, Cursor, ChatGPT, Claude) working on the Ziva Wernick portfolio project. It outlines the project structure, coding standards, and architectural decisions to ensure consistent, high-quality contributions.
 
 ## Project Overview
 
-- **Name:** Accessible Astro Starter
-- **Framework:** Astro 5.16.0+
-- **Styling:** Tailwind CSS 4.1+ (using `@tailwindcss/vite`)
+- **Name:** Ziva Wernick — personal website & portfolio (built on the Accessible Astro Starter template)
+- **Framework:** Astro 6+
+- **Styling:** Tailwind CSS 4+ (using `@tailwindcss/vite`)
 - **Language:** TypeScript (Strict mode)
 - **Accessibility Goal:** WCAG 2.2 AA and European Accessibility Act (EAA) compliance.
 
@@ -36,7 +36,7 @@ This document provides essential context for AI agents (like GitHub Copilot, Cur
 - **Reduced Motion:** Always consider `motion-safe` and `motion-reduce` utilities.
 
 ### 3. Content Management
-- **Content Collections:** Defined in `src/content/config.ts`.
+- **Content Collections:** Defined in `src/content.config.ts`.
 - **Markdown/MDX:** Located in `src/content/`.
 - **Assets:** Images should be optimized using Astro's `<Image />` component or similar.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# Project Context for Claude Code
+
+The AI-agent context, coding standards, and architectural conventions for this
+project are maintained in a single source of truth: **`AGENTS.md`** (shared with
+other AI assistants such as Cursor and GitHub Copilot).
+
+Claude Code imports it automatically below — keep project guidance in `AGENTS.md`,
+not here, so both tools stay in sync.
+
+@AGENTS.md


### PR DESCRIPTION
Updates `AGENTS.md` to current project facts (Astro 6, portfolio name, correct content-config path) and adds a public `CLAUDE.md` that imports it as a single source of truth.